### PR TITLE
ALT-11006 Fix SDK selection blocked in 2026.1

### DIFF
--- a/gradle-261.properties
+++ b/gradle-261.properties
@@ -4,8 +4,8 @@ customUntilBuild=261.*
 # Existent IDE versions can be found in the following repos:
 # https://www.jetbrains.com/intellij-repository/releases/
 # https://www.jetbrains.com/intellij-repository/snapshots/
-#261.22158.234
-ideaVersion=IU-261.22158-EAP-CANDIDATE-SNAPSHOT
-clionVersion=CL-261.22158-EAP-CANDIDATE-SNAPSHOT
-pycharmVersion=PC-261.22158-EAP-CANDIDATE-SNAPSHOT
-riderVersion=RD-2026.1-RC1-SNAPSHOT
+#261.22158.*
+ideaVersion=IU-2026.1
+clionVersion=CL-2026.1
+pycharmVersion=PC-2026.1
+riderVersion=RD-2026.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # supported values: 252, 253, 261
 environmentName=261
 
-pluginVersion=2026.10
+pluginVersion=2026.11
 
 # type of IDE (IDEA, CLion, etc.) used to build/test running
 # for more details see `Different IDEs` section in `PlatformVersions.md`

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # supported values: 252, 253, 261
 environmentName=261
 
-pluginVersion=2026.9
+pluginVersion=2026.10
 
 # type of IDE (IDEA, CLion, etc.) used to build/test running
 # for more details see `Different IDEs` section in `PlatformVersions.md`

--- a/intellij-plugin/hs-jvm-core/resources/messages/EduJVMBundle.properties
+++ b/intellij-plugin/hs-jvm-core/resources/messages/EduJVMBundle.properties
@@ -1,8 +1,8 @@
 # Errors
 error.no.jdk=JDK is not selected. In the settings section, choose or download some JDK
 error.no.jdk.need.at.least=JDK is not selected. In the settings section, choose or download some JDK with a version at least {0}
-error.no.jdk.available=No JDK found on your system. Please <a href="{0}">configure JDK</a> in IDE settings
-error.jdk.loading.failed=Failed to load JDK list. Please check your IDE settings or <a href="{0}">configure JDK manually</a>
+error.no.jdk.available=No JDK found on your system. Please configure JDK in IDE settings
+error.jdk.loading.failed=Failed to load JDK list. Please check your IDE settings or configure JDK manually
 error.no.main=Unable to execute task `{0}`, main method is missing
 # Ex.: Gradle project isn't imported. <a href="reload_gradle">Reload Gradle project</a>. For more information, see <a href="">the Troubleshooting guide</a>
 error.gradle.not.imported=Gradle project isn''t imported. <a href="{0}">Reload Gradle project</a>. For more information, see <a href="{1}">the Troubleshooting guide</a>

--- a/intellij-plugin/hs-jvm-core/src/org/hyperskill/academy/jvm/JdkLanguageSettings.kt
+++ b/intellij-plugin/hs-jvm-core/src/org/hyperskill/academy/jvm/JdkLanguageSettings.kt
@@ -32,6 +32,7 @@ private val LOG = logger<JdkLanguageSettings>()
 
 open class JdkLanguageSettings : LanguageSettings<JdkProjectSettings>() {
 
+  @Volatile
   protected var jdk: Sdk? = null
   protected val sdkModel: ProjectSdksModel = createSdkModel()
 
@@ -145,52 +146,58 @@ open class JdkLanguageSettings : LanguageSettings<JdkProjectSettings>() {
     jdkComboBox.isEnabled = false
 
     runInBackground(course.project, EduJVMBundle.message("progress.setting.suitable.jdk"), false) {
-      // Reset SDK model off-EDT to avoid IllegalStateException from synchronous progress on EDT
       try {
-        val project = course.project
-        if (project != null) {
-          sdksModel.reset(project)
+        // Reset SDK model off-EDT to avoid IllegalStateException from synchronous progress on EDT
+        try {
+          val project = course.project
+          if (project != null) {
+            sdksModel.reset(project)
+          }
+        }
+        catch (e: Throwable) {
+          loadingState = JdkLoadingState.FAILED
+          // best-effort; if reset fails we'll try with whatever the model currently has
+          loadingError = e.message
+        }
+
+        // Add bundled JDK if needed (must be done off-EDT as addSdk requires write action)
+        try {
+          addBundledJdkIfNeeded(sdksModel)
+        }
+        catch (_: Throwable) {
+          // best-effort; ignore failures
+        }
+
+        // If sdkModel is empty, try to get JDKs directly from ProjectJdkTable
+        jdk = findSuitableJdk(minJvmSdkVersion(course), sdksModel)
+              ?: findSuitableJdkFromTable(minJvmSdkVersion(course))
+
+        // Check if we found any JDK at all (either suitable or any)
+        if (sdksModel.sdks.all { it.sdkType != JavaSdk.getInstance() }
+            && ProjectJdkTable.getInstance().getSdksOfType(JavaSdk.getInstance()).isEmpty()) {
+          throw RuntimeException(EduJVMBundle.message("error.no.jdk.available"))
+        }
+
+        loadingState = JdkLoadingState.LOADED
+        loadingError = null
+
+        runInBackground(course.project, EduJVMBundle.message("progress.warming.suitable.jdk"), false) {
+          // Pre-warm SDK validation and VFS lookups off the EDT to avoid slow operations during UI rendering
+          prewarmSdkValidation(jdk)
         }
       }
       catch (e: Throwable) {
+        LOG.warn("Failed to preselect JDK", e)
         loadingState = JdkLoadingState.FAILED
-        // best-effort; if reset fails we'll try with whatever the model currently has
         loadingError = e.message
       }
+      finally {
+        invokeLater(ModalityState.any()) {
+          jdkComboBox.isEnabled = true
+          jdkComboBox.selectedJdk = jdk
 
-      // Add bundled JDK if needed (must be done off-EDT as addSdk requires write action)
-      try {
-        addBundledJdkIfNeeded(sdksModel)
-      }
-      catch (_: Throwable) {
-        // best-effort; ignore failures
-      }
-
-      // If sdkModel is empty, try to get JDKs directly from ProjectJdkTable
-      val suitableJdk = findSuitableJdk(minJvmSdkVersion(course), sdksModel)
-        ?: findSuitableJdkFromTable(minJvmSdkVersion(course))
-
-      // Check if we found any JDK at all (either suitable or any)
-      val anyJdkAvailable = sdksModel.sdks.any { it.sdkType == JavaSdk.getInstance() }
-                            || ProjectJdkTable.getInstance().getSdksOfType(JavaSdk.getInstance()).isNotEmpty()
-
-      loadingState = if (anyJdkAvailable) JdkLoadingState.LOADED
-      else JdkLoadingState.FAILED
-
-      loadingError = if (anyJdkAvailable) null
-      else EduJVMBundle.message("error.no.jdk.available")
-
-      runInBackground(course.project, EduJVMBundle.message("progress.warming.suitable.jdk"), false) {
-        // Pre-warm SDK validation and VFS lookups off the EDT to avoid slow operations during UI rendering
-        prewarmSdkValidation(suitableJdk)
-      }
-
-      invokeLater(ModalityState.any()) {
-        jdkComboBox.isEnabled = true
-        jdkComboBox.selectedJdk = suitableJdk
-        jdk = suitableJdk
-
-        notifyListeners()
+          notifyListeners()
+        }
       }
     }
   }

--- a/intellij-plugin/hs-jvm-core/src/org/hyperskill/academy/jvm/JdkLanguageSettings.kt
+++ b/intellij-plugin/hs-jvm-core/src/org/hyperskill/academy/jvm/JdkLanguageSettings.kt
@@ -142,9 +142,6 @@ open class JdkLanguageSettings : LanguageSettings<JdkProjectSettings>() {
     loadingState = JdkLoadingState.LOADING
     loadingError = null
 
-    // Disable combo box while loading to indicate loading state
-    jdkComboBox.isEnabled = false
-
     runInBackground(course.project, EduJVMBundle.message("progress.setting.suitable.jdk"), false) {
       try {
         // Reset SDK model off-EDT to avoid IllegalStateException from synchronous progress on EDT
@@ -193,7 +190,6 @@ open class JdkLanguageSettings : LanguageSettings<JdkProjectSettings>() {
       }
       finally {
         invokeLater(ModalityState.any()) {
-          jdkComboBox.isEnabled = true
           jdkComboBox.selectedJdk = jdk
 
           notifyListeners()


### PR DESCRIPTION
## Summary

- Wrap `preselectJdk` background task in try/finally to guarantee the JDK combo box is always re-enabled
- On failure, set `FAILED` loading state so validation shows a meaningful error instead of staying in `Pending` forever
- Simplify availability check by throwing on missing JDKs (handled uniformly in catch)

## Test plan

- [ ] Open a Hyperskill project via "Solve in IDE" in IntelliJ 2026.1 with JDKs installed — SDK should be auto-selected
- [ ] Open a Hyperskill project with no JDKs installed — combo box should be enabled, error message shown
- [ ] Verify macOS and Windows