### PR TITLE
Fix CLAUDE.md: use correct test task for hs-core tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,14 +15,15 @@ with [Hyperskill](https://hi.hyperskill.org/how-we-teach).
 ./gradlew buildPlugin
 
 # Run tests for a specific module
-./gradlew :intellij-plugin:hs-core:test
+# Note: hs-core tests must run via :intellij-plugin:test (hs-core uses base plugin without test runtime)
+./gradlew :intellij-plugin:test
 ./gradlew :intellij-plugin:hs-Java:test
 
 # Run a single test class
-./gradlew :intellij-plugin:hs-core:test --tests "org.hyperskill.academy.learning.format.CourseFormatTest"
+./gradlew :intellij-plugin:test --tests "org.hyperskill.academy.learning.format.CourseFormatTest"
 
 # Run a single test method
-./gradlew :intellij-plugin:hs-core:test --tests "org.hyperskill.academy.learning.format.CourseFormatTest.testSomething"
+./gradlew :intellij-plugin:test --tests "org.hyperskill.academy.learning.format.CourseFormatTest.testSomething"
 
 # Run IDE with the plugin (various IDEs supported)
 ./gradlew runIde          # Default IDE based on baseIDE property


### PR DESCRIPTION
## Summary
- Fix incorrect test commands in CLAUDE.md that referenced `:intellij-plugin:hs-core:test`
- hs-core uses `org.jetbrains.intellij.platform.base` which doesn't provide test runtime classpath, causing `NoClassDefFoundError: BasePlatformTestCase`
- Correct task is `:intellij-plugin:test` (which includes hs-core test sources)

## Test plan
- [x] Verified `:intellij-plugin:hs-core:test` fails with `NoClassDefFoundError: BasePlatformTestCase`
- [x] Confirmed CI uses `:intellij-plugin:test` (not `:intellij-plugin:hs-core:test`)
- [x] Confirmed `testCompileClasspath` has `test-framework` but `testRuntimeClasspath` does not for hs-core module

🤖 Generated with [Claude Code](https://claude.com/claude-code)