### PR TITLE
ALT-10998 [IDE Plugin] Code files are not transferred to the next stage

### DIFF
--- a/intellij-plugin/hs-core/src/org/hyperskill/academy/learning/framework/impl/FrameworkLessonManagerImpl.kt
+++ b/intellij-plugin/hs-core/src/org/hyperskill/academy/learning/framework/impl/FrameworkLessonManagerImpl.kt
@@ -15,9 +15,11 @@ import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.SlowOperations
 import org.hyperskill.academy.learning.*
+import org.hyperskill.academy.learning.configuration.excludeFromArchive
 import org.hyperskill.academy.learning.courseFormat.CheckStatus
 import org.hyperskill.academy.learning.courseFormat.FrameworkLesson
 import org.hyperskill.academy.learning.courseFormat.TaskFile
+import org.hyperskill.academy.learning.courseFormat.ext.configurator
 import org.hyperskill.academy.learning.courseFormat.ext.getDir
 import org.hyperskill.academy.learning.courseFormat.ext.isTestFile
 import org.hyperskill.academy.learning.courseFormat.ext.shouldBePropagated
@@ -950,18 +952,26 @@ class FrameworkLessonManagerImpl(private val project: Project) : FrameworkLesson
   ): UserChanges {
     val changes = mutableListOf<Change>()
 
+    // 1. Propagate user-created files from current state that are NOT in target template
+    for ((path, text) in currentState) {
+      if (path !in targetState) {
+        LOG.info("First visit: propagating user-created file '$path'")
+        changes += Change.PropagateLearnerCreatedTaskFile(path, text)
+      }
+    }
+
+    // 2. Handle files from target template
     for ((path, text) in targetState) {
       val taskFile = targetTask.taskFiles[path]
       val isPropagatable = taskFile?.shouldBePropagated() ?: true
 
       if (isPropagatable) {
-        // Propagatable files: only add if NEW (not in current state)
-        // Files in both: keep current (no change)
-        // Files in current but not target: keep (no removal)
+        // If it's a new template file in target stage, we must add it as a regular file
         if (path !in currentState) {
-          LOG.info("First visit: adding new propagatable file '$path'")
-          changes += Change.PropagateLearnerCreatedTaskFile(path, text)
+          LOG.info("First visit: adding new template file '$path'")
+          changes += Change.AddFile(path, text)
         }
+        // If it's in both, we keep the user's version from currentState (it's already on disk)
       }
       else {
         // Non-propagatable files (e.g., read-only reference files):
@@ -971,7 +981,7 @@ class FrameworkLessonManagerImpl(private val project: Project) : FrameworkLesson
       }
     }
 
-    LOG.info("First visit changes: ${changes.size} changes (new files)")
+    LOG.info("First visit changes: ${changes.size} changes")
     return UserChanges(changes)
   }
 
@@ -1300,12 +1310,11 @@ class FrameworkLessonManagerImpl(private val project: Project) : FrameworkLesson
     val currentTask = lesson.currentTask() ?: return
     val taskDir = currentTask.getDir(project.courseDir) ?: return
 
-    // Get user file keys (propagatable files)
-    val userFileKeys = originalTemplateFilesCache[currentTask.id]?.keys ?: currentTask.allFiles.keys
-    if (userFileKeys.isEmpty()) return
-
-    // Read current disk state (only user files)
-    val currentDiskState = getTaskStateFromFiles(userFileKeys, taskDir)
+    // Read current disk state (all files including user-created).
+    // Note: do NOT early-return when propagatableFiles is empty — the user may have legitimately
+    // deleted every editable file, and the snapshot must be updated to reflect that. The equality
+    // check below will short-circuit cases where there is genuinely nothing to save.
+    val currentDiskState = getAllFilesFromTaskDir(taskDir, currentTask)
     val (propagatableFiles, _) = currentDiskState.split(currentTask)
 
     // Check if there are actual changes compared to saved snapshot (compare only user files)
@@ -1317,7 +1326,9 @@ class FrameworkLessonManagerImpl(private val project: Project) : FrameworkLesson
     }
 
     // Extract only user files from existing snapshot for comparison
-    val existingUserFiles = existingSnapshot.filterKeys { it in userFileKeys }
+    val existingUserFiles = existingSnapshot.filterKeys { path ->
+      currentTask.getTaskFile(path)?.shouldBePropagated() ?: true
+    }
     if (propagatableFiles == existingUserFiles) {
       // No changes to save
       return
@@ -1368,10 +1379,12 @@ class FrameworkLessonManagerImpl(private val project: Project) : FrameworkLesson
     val result = HashMap<String, String>()
     val documentManager = FileDocumentManager.getInstance()
     val testDirs = task.testDirs
+    val configurator = task.course.configurator
 
     // Recursively collect all files from task directory
     fun collectFiles(dir: VirtualFile, pathPrefix: String = "") {
       for (child in dir.children) {
+        if (configurator?.excludeFromArchive(project, child) == true) continue
         val relativePath = if (pathPrefix.isEmpty()) child.name else "$pathPrefix/${child.name}"
 
         if (child.isDirectory) {

--- a/intellij-plugin/hs-core/testSrc/org/hyperskill/academy/learning/actions/navigate/FrameworkLessonUserFilesPropagationTest.kt
+++ b/intellij-plugin/hs-core/testSrc/org/hyperskill/academy/learning/actions/navigate/FrameworkLessonUserFilesPropagationTest.kt
@@ -1,0 +1,129 @@
+package org.hyperskill.academy.learning.actions.navigate
+
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import org.hyperskill.academy.learning.courseFormat.CheckStatus
+import org.hyperskill.academy.learning.courseFormat.InMemoryTextualContents
+import org.hyperskill.academy.learning.courseGeneration.GeneratorUtils.createChildFile
+import org.hyperskill.academy.learning.actions.NextTaskAction
+import org.hyperskill.academy.learning.actions.PreviousTaskAction
+import org.hyperskill.academy.learning.configurators.FakeGradleBasedLanguage
+import org.hyperskill.academy.learning.courseFormat.Course
+import org.hyperskill.academy.learning.courseFormat.hyperskill.HyperskillCourse
+import org.hyperskill.academy.learning.findTask
+import org.hyperskill.academy.learning.testAction
+import org.hyperskill.academy.learning.courseFormat.FrameworkLesson
+import org.hyperskill.academy.learning.framework.FrameworkLessonManager
+import org.junit.Test
+import org.junit.Assert.*
+
+class FrameworkLessonUserFilesPropagationTest : NavigationTestBase() {
+
+  @Test
+  fun `test user-created files propagated and registered in next stage`() {
+    val course = createHyperskillProjectCourse()
+    val task1 = course.findTask("project", "stage1")
+    val task2 = course.findTask("project", "stage2")
+
+    withVirtualFileListener(course) {
+      task1.openTaskFileInEditor("src/Task.kt")
+      task1.status = CheckStatus.Solved
+
+      // Create user file in task1
+      val taskDir = rootDir.findFileByRelativePath("project/task") ?: error("Task directory not found")
+      runWriteAction {
+        createChildFile(project, taskDir, "src/UserFile.kt", InMemoryTextualContents("class UserClass {}"))
+      }
+
+      // Navigate to task2
+      testAction(NextTaskAction.ACTION_ID)
+
+      // 1. Verify user file is on disk
+      val userFile = taskDir.findFileByRelativePath("src/UserFile.kt")
+      assertNotNull("User file should be on disk after navigation to task2", userFile)
+
+      // 2. Verify user file is registered in task2's taskFiles
+      val taskFile = task2.getTaskFile("src/UserFile.kt")
+      assertNotNull("User file should be registered in task2 taskFiles", taskFile)
+      assertTrue("User file should be marked as learner created", taskFile!!.isLearnerCreated)
+    }
+  }
+
+  @Test
+  fun `test excluded files are NOT captured in snapshot`() {
+    val course = createHyperskillProjectCourse()
+    val task1 = course.findTask("project", "stage1")
+
+    withVirtualFileListener(course) { 
+      task1.openTaskFileInEditor("src/Task.kt")
+      task1.status = CheckStatus.Solved
+
+      // Create excluded directory and file
+      val taskDir = rootDir.findFileByRelativePath("project/task") ?: error("Task directory not found")
+      runWriteAction {
+        val buildDir = taskDir.createChildDirectory(this, ".build")
+        buildDir.createChildData(this, "some_generated_file.txt")
+      }
+
+      // Navigate to task2 (this triggers saveCurrentTaskSnapshot for task1)
+      testAction(NextTaskAction.ACTION_ID)
+
+      // Verify that 'build/' is NOT in task1's snapshot in storage
+      val manager = FrameworkLessonManager.getInstance(project)
+      val task1State = manager.getTaskState(task1.lesson as FrameworkLesson, task1)
+      assertFalse("Excluded file should not be in task state", task1State.containsKey(".build/some_generated_file.txt"))
+    }
+  }
+
+  @Test
+  fun `test auto-save persists deletion of all propagatable files to snapshot`() {
+    val course = createHyperskillProjectCourse()
+    val task1 = course.findTask("project", "stage1")
+    val task2 = course.findTask("project", "stage2")
+
+    withVirtualFileListener(course) {
+      task1.openTaskFileInEditor("src/Task.kt")
+
+      // Navigate forward to task2 to establish a snapshot baseline that contains src/Task.kt.
+      testAction(NextTaskAction.ACTION_ID)
+
+      val taskDir = rootDir.findFileByRelativePath("project/task") ?: error("Task directory not found")
+      assertNotNull("Baseline: src/Task.kt should exist on disk in task2", taskDir.findFileByRelativePath("src/Task.kt"))
+
+      // Delete the only propagatable file from disk, then trigger auto-save (Ctrl+S equivalent).
+      runWriteAction {
+        taskDir.findFileByRelativePath("src/Task.kt")?.delete(this)
+      }
+      FileDocumentManager.getInstance().saveAllDocuments()
+
+      // Navigate BACK to task1. Backward navigation does not overwrite task2's snapshot,
+      // so any state left there by auto-save is preserved for inspection.
+      testAction(PreviousTaskAction.ACTION_ID)
+
+      // With the bug, saveCurrentTaskSnapshot bailed out when propagatableFiles was empty,
+      // leaving src/Task.kt in task2's snapshot — which would resurrect the file on next visit.
+      val manager = FrameworkLessonManager.getInstance(project)
+      val task2State = manager.getTaskState(task2.lesson as FrameworkLesson, task2)
+      assertFalse(
+        "Snapshot must reflect deletion: src/Task.kt should not be in task2 state after auto-save",
+        task2State.containsKey("src/Task.kt")
+      )
+    }
+  }
+
+  private fun createHyperskillProjectCourse(): Course = courseWithFiles(
+    language = FakeGradleBasedLanguage,
+    courseProducer = ::HyperskillCourse
+  ) {
+    frameworkLesson("project", isTemplateBased = false) {
+      eduTask("stage1", stepId = 2001) {
+        taskFile("src/Task.kt", "// Stage 1 template")
+        taskFile("test/Tests1.kt", "fun tests1() {}")
+      }
+      eduTask("stage2", stepId = 2002) {
+        taskFile("src/Task.kt", "// Stage 2 template")
+        taskFile("test/Tests2.kt", "fun tests2() {}")
+      }
+    }
+  }
+}


### PR DESCRIPTION
This update addresses issues where code files (both user-created and template additions) were not correctly transferred between stages in Framework Lessons. It also improves the reliability of the auto-save mechanism and ensures that generated or excluded files do not pollute the task snapshots.

#### Key Improvements

*   **Fixed Stage-to-Stage File Propagation**:
    *   Corrected the "first-visit" logic to ensure that files created by the learner in previous stages are properly propagated and registered in the next stage's task files.
    *   Ensured that new template files introduced in later stages are correctly added to the project state without being overwritten or ignored.
*   **Enhanced Snapshot Accuracy**:
    *   **Persistence of Deletions**: Fixed a bug where deleting all editable files would cause the auto-save to bail out, resulting in "resurrection" of deleted files upon returning to the stage. Deletions are now correctly persisted to the snapshot.
    *   **Configurable Exclusions**: Integrated the course configurator's exclusion rules (e.g., ignoring `.build/` or `.gradle/` folders) into the snapshot process to prevent internal or generated files from being tracked.
*   **Added Regression Tests**:
    *   Introduced `FrameworkLessonUserFilesPropagationTest.kt` to verify:
        *   Learner-created files are correctly marked as `isLearnerCreated` and carried forward.
        *   Excluded files/directories are omitted from the storage snapshot.
        *   Auto-save correctly handles the state where all propagatable files are removed.

#### Technical Details
*   **`FrameworkLessonManagerImpl.kt`**:
    *   Updated `calculateFirstVisitChanges` to separate propagation of user-created files from the addition of new template files.
    *   Refactored `saveCurrentTaskSnapshot` to use `getAllFilesFromTaskDir` and apply configurator-based filtering.
    *   Modified the change detection logic to ensure snapshots are updated even when the resulting set of propagatable files is empty.