### PR TITLE
[ALT-11013] Never pass test files as is_visible=true to backend

### DIFF
--- a/intellij-plugin/hs-core/src/org/hyperskill/academy/learning/submissions/utils.kt
+++ b/intellij-plugin/hs-core/src/org/hyperskill/academy/learning/submissions/utils.kt
@@ -16,6 +16,7 @@ import org.hyperskill.academy.learning.courseFormat.EduFormatNames.CORRECT
 import org.hyperskill.academy.learning.courseFormat.TaskFile
 import org.hyperskill.academy.learning.courseFormat.ext.findTaskFileInDir
 import org.hyperskill.academy.learning.courseFormat.ext.getDir
+import org.hyperskill.academy.learning.courseFormat.ext.isTestFile
 import org.hyperskill.academy.learning.courseFormat.tasks.Task
 import org.hyperskill.academy.learning.taskToolWindow.ui.styleManagers.StyleResourcesManager
 import org.hyperskill.academy.learning.taskToolWindow.ui.styleManagers.TaskToolWindowBundle
@@ -40,7 +41,8 @@ fun getSolutionFiles(project: Project, task: Task): List<SolutionFile> {
       val document = FileDocumentManager.getInstance().getDocument(virtualFile) ?: return@runReadAction
       val text = document.text
       val builder = StringBuilder(text)
-      files.add(SolutionFile(taskFile.name, builder.toString(), taskFile.isVisible))
+      val isVisible = if (!taskFile.isLearnerCreated && taskFile.isTestFile) false else taskFile.isVisible
+      files.add(SolutionFile(taskFile.name, builder.toString(), isVisible))
     }
   }
 

--- a/intellij-plugin/hs-core/src/org/hyperskill/academy/learning/submissions/utils.kt
+++ b/intellij-plugin/hs-core/src/org/hyperskill/academy/learning/submissions/utils.kt
@@ -41,7 +41,7 @@ fun getSolutionFiles(project: Project, task: Task): List<SolutionFile> {
       val document = FileDocumentManager.getInstance().getDocument(virtualFile) ?: return@runReadAction
       val text = document.text
       val builder = StringBuilder(text)
-      val isVisible = if (!taskFile.isLearnerCreated && taskFile.isTestFile) false else taskFile.isVisible
+      val isVisible = !taskFile.isTestFile && taskFile.isVisible
       files.add(SolutionFile(taskFile.name, builder.toString(), isVisible))
     }
   }

--- a/intellij-plugin/hs-core/testSrc/org/hyperskill/academy/learning/stepik/hyperskill/HyperskillUploadingTest.kt
+++ b/intellij-plugin/hs-core/testSrc/org/hyperskill/academy/learning/stepik/hyperskill/HyperskillUploadingTest.kt
@@ -21,6 +21,29 @@ class HyperskillUploadingTest : EduTestCase() {
     }
   }
 
+  @Test
+  fun `test collect solution files - test file with wrong visible=true is sent as is_visible=false`() {
+    val course = courseWithFiles(
+      language = FakeGradleBasedLanguage,
+      courseProducer = ::HyperskillCourse
+    ) {
+      frameworkLesson("lesson1") {
+        eduTask("task1", stepId = 1) {
+          taskFile("src/Task.kt", "fun foo() {}", visible = true)
+          taskFile("test/Tests1.kt", "fun tests1() {}", visible = true) // wrong: visible=true for test file
+        }
+      }
+    } as HyperskillCourse
+    course.hyperskillProject = HyperskillProject()
+    course.stages = listOf(HyperskillStage(1, "", 1))
+
+    val task = course.findTask("lesson1", "task1")
+    val files = getSolutionFiles(project, task)
+    assertEquals(2, files.size)
+    assertEquals(true, files.find { it.name == "src/Task.kt" }?.isVisible)
+    assertEquals(false, files.find { it.name == "test/Tests1.kt" }?.isVisible)
+  }
+
   private fun createHyperskillCourse(): HyperskillCourse {
     val course = courseWithFiles(
       language = FakeGradleBasedLanguage,


### PR DESCRIPTION
For an unknown reason, some files are marked as `is_visible=true` when sent to backend, even though originally (from api/steps response) they were `is_visible=false`.
This simple fix prevents test files from every being visible when posting submission to backend.